### PR TITLE
Python2 compatible way of getting the docs version

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -15,7 +15,6 @@
 
 import sys
 import os
-from ast import parse
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -69,10 +68,14 @@ author = 'Gustavo Silva, Brendt Wohlberg'
 # built documents.
 #
 # The short X.Y version.
-with open(os.path.join('../../sporco_cuda', '__init__.py')) as f:
-    version = parse(next(filter(
-        lambda line: line.startswith('__version__'),
-        f))).body[0].value.s
+base_dir = os.path.join(os.path.abspath(os.path.dirname(__file__)), '../..')
+with open(os.path.join(base_dir, 'sporco_cuda/__init__.py')) as f:
+    for line in f.readlines():
+        if line.startswith('__version__'):
+            version_info = {}
+            exec(line, None, version_info)
+            version = version_info['__version__']
+            break
 # The full version, including alpha/beta/rc tags.
 release = version
 


### PR DESCRIPTION
In Python2, the `filter` function returns a list instead of an iterator. As a result, you'll see `TypeError: list object is not an iterator` when you try to call `next` on it. This change fixes that.